### PR TITLE
Fixed password generator

### DIFF
--- a/passvault-client/src/main/java/org/passvault/client/generator/GeneratorParameters.java
+++ b/passvault-client/src/main/java/org/passvault/client/generator/GeneratorParameters.java
@@ -16,7 +16,7 @@ public record GeneratorParameters(char[] characters, char[] specialChars, int pa
 	
 	public static final char[] LOWERCASE_ALPHABET = "abcdefghijklmnopqrstuvwxyz".toCharArray();
 	public static final char[] UPPERCASE_ALPHABET = "ABCDEFGHIJKLMNOPQRSTUVWXYZ".toCharArray();
-	public static final char[] NUMBERS = "012345678".toCharArray();
+	public static final char[] NUMBERS = "0123456789".toCharArray();
 	public static final char[] DEFAULT_SPECIAL_CHARS = "!@#$%^&*?".toCharArray();
 	
 	/**


### PR DESCRIPTION
Fixed generator not using `9` number while generating password